### PR TITLE
Numpy>=1.24; YouTokenToMe from LahiLuk fork

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 huggingface_hub
 numba
-numpy>=1.22,<1.24
+numpy>=1.24
 onnx>=1.7.0
 python-dateutil
 ruamel.yaml

--- a/requirements/requirements_common.txt
+++ b/requirements/requirements_common.txt
@@ -3,4 +3,4 @@ pandas
 pydantic<2  # remove after inflect supports Pydantic 2.0+
 sacremoses>=0.0.43
 sentencepiece<1.0.0
-youtokentome>=1.0.5
+youtokentome @ git+https://github.com/LahiLuk/YouTokenToMe@master


### PR DESCRIPTION
I created the riverside/main branch because starting from release v1.22.0 of the main Nvidia/NeMo repo, they use syntax only supported by python3.10 which breaks everything.

**The riverside/main branch is forked from v1.21.0**
This commit fixes dependency issues (YouTokenToMe needing cython, and numpy>=1.24 to match ai-common requirements).

PS: The unsupported syntax is that they use the | operand instead of Union to specify multiple possible types.
`somevar: str | List[str]`  <-- They do this which breaks python3.9
`somevar: Union[str, List[str]]`